### PR TITLE
Better rendering

### DIFF
--- a/app/assets/javascripts/templates/profile/index.hbs
+++ b/app/assets/javascripts/templates/profile/index.hbs
@@ -1,9 +1,9 @@
-<h1>{{nickname}}'s profile</h1>
+<h1>{{nickname}}'s private profile</h1>
 <p>
 	mail: {{email}}
 </p>
 <p>profile picture: </p>
-<img src="{{image}}" style="max-height: 600px;">
+<img src="{{image}}" style="max-height: 200px;">
 <br>
 <a href="#profile/edit">Edit</a>
 <br>

--- a/app/assets/javascripts/templates/profile/showProfile.hbs
+++ b/app/assets/javascripts/templates/profile/showProfile.hbs
@@ -1,7 +1,7 @@
 {{#if user}}
 {{user.nickname}}
 <br>
-{{user.email}}
+<img src="{{user.image}}" style="max-height: 200px;">
 <br>
 <h3>Guild</h3>
 	{{#if guild}}

--- a/app/assets/javascripts/utils/changes.js
+++ b/app/assets/javascripts/utils/changes.js
@@ -7,6 +7,9 @@
 // should return false
 
 App.utils.onlyThoseAttrsChanged = (changedObj, arr) => {
+	if (_.isEmpty(changedObj)) { // changedObj is empty when a new object is added into a collection
+		return (false);
+	}
 	for (let key in changedObj) {
 		if (_.findIndex(arr, attr => attr == key) == -1) {
 			return (false); // some attribute not specified in arr changed

--- a/app/assets/javascripts/utils/changes.js
+++ b/app/assets/javascripts/utils/changes.js
@@ -1,0 +1,16 @@
+
+// utility to check if only certain fields changed
+// usage: 
+// onlyThoseAttrsChanged({"attribute_1": "I changed"}, ["attribute_1"])
+// should return true
+// onlyThoseAttrsChanged({"attribute_2": "I changed"}, ["attribute_1"])
+// should return false
+
+App.utils.onlyThoseAttrsChanged = (changedObj, arr) => {
+	for (let key in changedObj) {
+		if (_.findIndex(arr, attr => attr == key) == -1) {
+			return (false); // some attribute not specified in arr changed
+		}
+	}
+	return (true); // only attributes specified in arr changed
+}

--- a/app/assets/javascripts/views/admin/AdminView.js
+++ b/app/assets/javascripts/views/admin/AdminView.js
@@ -37,7 +37,10 @@ AppClasses.Views.Admin = class extends Backbone.View {
 	demoteUser(e) {
 		this.adminAction(e, "/api/admin/demote.json", "User demoted");
 	}
-	updateRender() {
+	updateRender(changes) {
+		if (changes && App.utils.onlyThoseAttrsChanged(changes.changed, ["last_seen"])) {
+			return (this);
+		}
 		this.$el.html(this.template({
 			user: this.model.toJSON(),
 			token: $('meta[name="csrf-token"]').attr('content'),

--- a/app/assets/javascripts/views/game/GamePlayView.js
+++ b/app/assets/javascripts/views/game/GamePlayView.js
@@ -13,7 +13,6 @@ AppClasses.Views.GamePlay = class extends Backbone.View {
 	}
 	render(room_id) {
 		this.updateRender(room_id); // generates HTML
-		// the game has to be started in the router
 		return (this);
 	}
 }

--- a/app/assets/javascripts/views/game/GameView.js
+++ b/app/assets/javascripts/views/game/GameView.js
@@ -10,7 +10,6 @@ AppClasses.Views.Game = class extends Backbone.View {
 	}
 	render() {
 		this.updateRender(); // generates HTML
-		// the game has to be started in the router
 		return (this);
 	}
 }

--- a/app/assets/javascripts/views/home/ConnectionInfoView.js
+++ b/app/assets/javascripts/views/home/ConnectionInfoView.js
@@ -6,7 +6,10 @@ AppClasses.Views.ConnectionInfos = class extends Backbone.View {
 		this.listenTo(this.model, "change", this.updateRender);
 		this.updateRender();
 	}
-	updateRender() {
+	updateRender(changes) {
+		if (changes && App.utils.onlyThoseAttrsChanged(changes.changed, ["last_seen"])) {
+			return (this);
+		}
 		this.$el.html(this.template({
 			user: this.model.attributes,
 			logoutLink: App.data.links.signout

--- a/app/assets/javascripts/views/home/HomeView.js
+++ b/app/assets/javascripts/views/home/HomeView.js
@@ -9,7 +9,10 @@ AppClasses.Views.Home = class extends Backbone.View {
 		this.listenTo(this.model, "change", this.updateRender);
 		this.updateRender();
 	}
-	updateRender() {
+	updateRender(changes) {
+		if (changes && App.utils.onlyThoseAttrsChanged(changes.changed, ["last_seen"])) {
+			return (this);
+		}
 		this.$el.html(this.template({
 			user: this.model.toJSON()
 		}));

--- a/app/assets/javascripts/views/profile/AuthInfosView.js
+++ b/app/assets/javascripts/views/profile/AuthInfosView.js
@@ -87,7 +87,10 @@ AppClasses.Views.AuthInfos = class extends Backbone.View {
 			}, 3000);
 		});
 	}
-	updateRender() {
+	updateRender(changes) {
+		if (changes && App.utils.onlyThoseAttrsChanged(changes.changed, ["last_seen"])) {
+			return (this);
+		}
 		this.$el.html(this.template({
 			user: this.model.attributes,
 			token: $('meta[name="csrf-token"]').attr('content'),

--- a/app/assets/javascripts/views/profile/ProfileEditView.js
+++ b/app/assets/javascripts/views/profile/ProfileEditView.js
@@ -23,7 +23,10 @@ AppClasses.Views.ProfileEdit = class extends Backbone.View {
 		});
 		return (false);
 	}
-	updateRender() {
+	updateRender(changes) {
+		if (changes && App.utils.onlyThoseAttrsChanged(changes.changed, ["last_seen"])) {
+			return (this);
+		}
 		this.$el.html(this.template({
 			user: this.model.attributes,
 			token: $('meta[name="csrf-token"]').attr('content')

--- a/app/assets/javascripts/views/profile/ProfileView.js
+++ b/app/assets/javascripts/views/profile/ProfileView.js
@@ -6,7 +6,10 @@ AppClasses.Views.Profile = class extends Backbone.View {
 		this.updateRender(); // render the template only one time, unless model changed
 		this.listenTo(this.model, "change", this.updateRender);
 	}
-	updateRender() {
+	updateRender(changes) {
+		if (changes && App.utils.onlyThoseAttrsChanged(changes.changed, ["last_seen"])) {
+			return (this);
+		}
 		this.$el.html(this.template(this.model.attributes));
 		return (this);
 	}

--- a/app/assets/javascripts/views/profile/ShowUserView.js
+++ b/app/assets/javascripts/views/profile/ShowUserView.js
@@ -11,14 +11,10 @@ AppClasses.Views.ShowUser = class extends Backbone.View {
 		this.guilds.fetch();
 		this.updateRender();
 	}
-	updateRender(changes) {
-		console.log(changes.changed)
-		if (changes && App.utils.onlyThoseAttrsChanged(changes.changed, ["last_seen"])) {
-			return (this);
-		}
+	updateRender() {
 		const user = this.model.findWhere({id: this.user_id});
 		const userJSON = user ? user.toJSON() : null;
-		const guild = userJSON ? this.guilds.findWhere({id: userJSON.guild_id}) : null;
+		const guild = userJSON && userJSON.guild_validated ? this.guilds.findWhere({id: userJSON.guild_id}) : null;
 		const guildJSON = guild ? guild.toJSON() : null;
 		this.$el.html(this.template({
 			user: userJSON,

--- a/app/assets/javascripts/views/profile/ShowUserView.js
+++ b/app/assets/javascripts/views/profile/ShowUserView.js
@@ -11,7 +11,11 @@ AppClasses.Views.ShowUser = class extends Backbone.View {
 		this.guilds.fetch();
 		this.updateRender();
 	}
-	updateRender() {
+	updateRender(changes) {
+		console.log(changes.changed)
+		if (changes && App.utils.onlyThoseAttrsChanged(changes.changed, ["last_seen"])) {
+			return (this);
+		}
 		const user = this.model.findWhere({id: this.user_id});
 		const userJSON = user ? user.toJSON() : null;
 		const guild = userJSON ? this.guilds.findWhere({id: userJSON.guild_id}) : null;

--- a/app/controllers/friends_controller.rb
+++ b/app/controllers/friends_controller.rb
@@ -9,7 +9,7 @@ class FriendsController < ApplicationController
 			format.html { redirect_to "/", notice: '^^' }
 			format.json { render json: User.all.to_json(
 				only: 
-					[:id, :nickname, :email, :image, :guild_validated, :guild_id, :last_seen, :admin, :banned]
+					[:id, :nickname, :image, :guild_validated, :guild_id, :last_seen]
 				), status: :ok
 			}
 		end

--- a/app/controllers/guilds_controller.rb
+++ b/app/controllers/guilds_controller.rb
@@ -6,7 +6,13 @@ class GuildsController < ApplicationController
   # GET /guilds
   # GET /guilds.json
   def index
-    @guilds = Guild.all
+    @guilds = Guild.all.map do |guild|
+      Guild.clean(guild)
+    end
+    respond_to do |format|
+			format.html { redirect_to "/", notice: ':)' }
+			format.json { render json: @guilds, status: :ok }
+		end
   end
 
   # GET /guilds/1

--- a/app/models/guild.rb
+++ b/app/models/guild.rb
@@ -7,4 +7,17 @@ class Guild < ApplicationRecord
 	validates :name, uniqueness: true
 	validates :anagram, uniqueness: true
 
+	def self.clean(guild)
+		newguild = {
+			id: guild.id,
+			name: guild.name,
+			anagram: guild.anagram,
+			points: guild.points,
+			owner: User.strict_clean(guild.owner),
+			users: guild.users.map { |usr| User.strict_clean(usr) },
+			officers: guild.officers.map { |usr| User.strict_clean(usr) },
+			requests: guild.requests.map { |usr| User.strict_clean(usr) }
+		}
+	end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,17 @@ class User < ApplicationRecord
       admin: usr.admin
     }
   end
+
+  def self.strict_clean(usr)
+		new_user = {
+      id: usr.id,
+      nickname: usr.nickname,
+      image: usr.image,
+      guild_validated: usr.guild_validated,
+      guild_id: usr.guild_id,
+      last_seen: usr.last_seen
+    }
+  end
   
   def self.reset_guild(usr)
     usr.guild_id = nil


### PR DESCRIPTION
Closes #11 
### les changements: 
- #### ajout de l'utilitaire `App.utils.onlyThoseAttrsChanged`
	- il sert a verifier si les proprietees qui ont change sont indispensable au rendu (et donc savoir si oui ou non on va update le rendu)
	- il s'utilise de la maniere suivante:
```js
// dans le constructor: 
this.listenTo(this.model, "change", this.updateRender);

// la fonction d'update du rendu:
updateRender(changes) {
	if (changes && App.utils.onlyThoseAttrsChanged(changes.changed, ["last_seen"])) {
		return (this);
	}
	this.$el.html(this.template({
		user: this.model.attributes,
		logoutLink: App.data.links.signout
	}));
	return (this);
}
```
Ici, on n'update pas le rendu lorsque la propriete qui a change est "last_seen"
En effet certaines vues n'utilisent pas cette propriete
Re render toutes les 10 secondes pour rien serait donc peu etre un peu abusé


- #### data cote client nettoyees:
Dans la propriete users de `App.collections.guilds` par exemple il y avait des infos privees comme l'email ou meme le bool qui signifiait que l'utilisateur avait active l'auth a 2 facteurs, bref c'est corrige maintenant on obtient bcp moins d'infos sur les autres utilisateurs du site en fouillant dans les collections

